### PR TITLE
README: Improved/fixed grammar, seperated languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,64 @@
+This readme is also [available in polish](./README.pl-PL.md)
+
 # beever-sample
 
-Simple project showing how to use beever library.
+A simple project demonstrating usage of the Beever library.
 
-To run a test you need to have a running Postgres, Redis and MongoDB - the easiest way is to use docker (there is ready to use `test-docker.sh`).
+To run a test you'll need to have a running Postgres, Redis and MongoDB - the
+easiest way to set them up is to use docker (with the `test-docker.sh` shell
+script we prepared).
+
 
 ## Beever Basics
 
-Beever to "framework" stworzony na bazie Vert.X przeznaczony do tworzenia serwerów REST API. Bardzo dobrze nadaje się do tworzenia zarówno prostych jak i bardzo złożonych systemów. Upraszcza i przyspiesza proces tworzenia. Skupiony jest na pracy nad "domeną" problemu, a nie na warstwach logicznych. Daje narzędzia do wygodnego tworzenia
-testów jednostkowych. Stosowana jest konwencja CoC (konwencja ponad konfiguracja) - czyli nie potrzeba dużo konfigurować, a wiele rzeczy "dzieje się" automatycznie według z góry okreslonej konwencji.
+Beever is a framework based on [Vert.X][1] designed for creating REST API
+servers. It's well-suited for creating both simple and very complex
+systems. Greatly simplifies and speeds up the development process. Beever is
+focused on the domain of the problem rather than the logical layers. It
+provides tools for comfortable unit tests. The convention over configuration
+principle is applied, so there's not much to configure and many things "happen"
+automatically according to the predetermined convention.
 
-Podstawowym elementem w tworzeniu serwera przy użyciu Beever jest Handler. Handler to pojedyncza klasa, implementująca interfejs `BeeverHandle`. Handler wykonuje czynność, która musi być prosta i testowalana (testy jednostkowe). Z założenia musi być NIE BLOKUJĄCA - czyli nie może blokować "event loop" na dłużej niż kilka sekund. W czas
-wykonania nie wlicza się czas wykonywania innych handlerów lub operacji asynchronicznych wołanych z tego handlera.
+The basic element in creating a server using Beever is a Handler.  A handler is
+a single class, implementing the `BeeverHandle` interface. It performs an
+action that must be simple and testable (unit tests). It has to be non-blocking
+by convention, so can't block the event loop for more than a couple seconds.
+The execution time is not affected by other handlers or asynchronous operations
+called from that handler.
+
 
 ### Handlers
 
-Handlers are simple, short and **not blocking** "methods". Each handler can be called by "name". Input and output - JSON Handler can be exposed as REST end point by adding annotation `@POST`, `@GET`.
+Handlers are simple, short and **non-blocking** "methods". Each handler can be
+called by "name". Input and output - JSON Handler can be exposed as REST end
+point by adding annotation `@POST`, `@GET`.
+
 
 #### Names of the handlers
 
-Each handler name should end with word `Handler`. Each REST handlers use special name convention:
-`PREFIX` `Name` `Handler`
+Each handler name should end with the word `Handler`. Each REST handler uses a
+special name convention: `<PREFIX><Name>Handler`, where `<PREFIX>` is
+substituted for one of the following Role specifiers:
 
-PREFIX determines required Role to call this end point:
+- `Public` - for end points anyone can call
+- `<RoleName>` e.g. `User` or `Admin` - names the `role` of the logged user.
+  More about users in the [Authorization](#authorization) section.
 
-- `Public` - everyone can call
-- `RoleName` - example: `User` or `Admin` - it names the `role` of the logged user. More about users in **Authorization** section.
+Example: `PublicSomeImportantCallHandler` - public (no user required) end point
+with path: `/some/important/call`.
 
-Example:
-`PublicSomeImportantCallHandler` - public (no user required) end point with path: `/some/important/call`
 
-### Input and Output of the handler
+<!-- The following level 3 heading did not have appropriate (or any for that
+matter) content associated with it and as such has been commented out until it
+gets updated.  --> 
+
+<!-- ### Input and Output of the handler -->
 
 ### Authorization
 
-The Beever uses similar to JWT technic to achieve authorization/authentication. To interact with fields of this key some annotations can be used.
+Beever uses a technique similar to [JWT][2] to achieve authorization/authentication.
+To interact with fields of this key some annotations can be used.
 
 
+[1]: https://en.wikipedia.org/wiki/Vert.x
+[2]: https://en.wikipedia.org/wiki/JSON_Web_Token 

--- a/README.pl-PL.md
+++ b/README.pl-PL.md
@@ -1,0 +1,54 @@
+Dostępna jest rowniez [wersja angielskojęzyczna](./README.md) tego pliku readme
+
+# beever-sample
+
+Prosty projekt demonstrujacy uzytek biblioteki Beever.
+
+Aby uruchomic test potrzebny jest dzialajacy Postgres, Redis i MongoDB - najprostszym
+sposobem na ich przygotowanie jest uzycie dockera (uzywajac `test-docker.sh`, skryptu powloki
+ktory przygotowalismy).
+
+## Podstawy Beevera
+
+Beever to "framework" stworzony na bazie [Vert.X][1] przeznaczony do tworzenia
+serwerów REST API.  Bardzo dobrze nadaje się do tworzenia zarówno prostych jak
+i bardzo złożonych systemów.  Upraszcza i przyspiesza proces tworzenia.
+Skupiony jest na pracy nad "domeną" problemu, a nie na warstwach logicznych.
+Daje narzędzia do wygodnego tworzenia testów jednostkowych.  Stosowana jest
+konwencja CoC (konwencja ponad konfiguracja) - czyli nie potrzeba dużo
+konfigurować, a wiele rzeczy "dzieje się" automatycznie według z góry
+okreslonej konwencji.
+
+Podstawowym elementem w tworzeniu serwera przy użyciu Beever jest Handler.
+Handler to pojedyncza klasa, implementująca interfejs `BeeverHandle`. Handler
+wykonuje czynność, która musi być prosta i testowalna (testy jednostkowe). Z
+założenia musi być NIE BLOKUJĄCA - czyli nie może blokować "event loop" na
+dłużej niż kilka sekund. W czas wykonania nie wlicza się czas wykonywania
+innych handlerów lub operacji asynchronicznych wołanych z tego handlera.
+
+### Handlery 
+Handlery to proste, krotkie i nie blokujące metody.  Kazdy handler
+moze byc wywolany "nazwą". Input i output - Handler JSON moze byc odslonięty
+jako punkt koncowy REST dodajac annotacje `@POST`, `@GET`.
+
+#### Nazwy handlerow
+
+Kazda nazwa handlera powinna konczyc sie na slowo `Handler`. Kazdy REST handler
+uzywa specjalnej konwencji nazwy: `<PREFIX><Name>Handler`, gdzie `<PREFIX>`
+jest podmieniony na jeden z ponizszych specyfikatorow roli:
+
+- `Public` - dla ktore moga byc przez kazdego
+- `<RoleName>` np. `User` lub `Admin` - nazywa `role` zalogowanego uzytkownika.
+  Wiecej o uzytkownikach w sekcji [Autoryzacja](#autoryzacja).
+
+Przyklad: `PublicSomeImportantCallHandler` - 'publiczny' (nie sa wymagane
+specjalne) punkt koncowy ze sciezka: `/some/imprtant/call`. 
+
+### Autoryzacja
+
+Beever uzywa techniki podobnej do [JWT][2] do osiagniecia
+autoryzacji/autentykacji.  Aby wejsc w interakcje z polami tego klucza moze byc
+uzywane kilka anotacji.
+
+[1]: https://en.wikipedia.org/wiki/Vert.x 
+[2]: https://en.wikipedia.org/wiki/JSON_Web_Token


### PR DESCRIPTION
The following changes have been made to the README:
- the wording was improved and grammatical errors were corrected

- the section initially written in polish was seperated into a newly created README.pl-PL file and substituted with the english translation. Additionally the polish readme was filled out with translations of all the remaining sections

- markdown links, section links and relative links implemented as follows:
    * pieces of software likely to be unknown to users provided with a wikipedia source
    * a relative link to the polish version of the readme at the top of the document
    * section link used for a single section reference instead of the previous bold style

- an entirely unused section was removed (commented out)

I'm not sure if this project is of any importance to you right now as it appears to be long unmaintained. I'm familiar with your business and would love to see Kanga enable more collaborative efforts through public repositories and [Free Software Licences](https://www.gnu.org/philosophy/free-sw.en.html) as they are values so close to the ones you promote, ones of decentralisation.

Also note that the polish version of the file needs to be revised before merging as I'm not fully confident about my level of polish and it's currently lacking diacritics all across.

Best Regards.